### PR TITLE
Add --cidenv flag

### DIFF
--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -72,6 +72,7 @@ type containerOptions struct {
 	oomKillDisable     bool
 	oomScoreAdj        int
 	containerIDFile    string
+	containerIDEnv     string
 	entrypoint         string
 	hostname           string
 	memory             opts.MemBytes
@@ -240,6 +241,7 @@ func addFlags(flags *pflag.FlagSet) *containerOptions {
 	flags.Uint16Var(&copts.blkioWeight, "blkio-weight", 0, "Block IO (relative weight), between 10 and 1000, or 0 to disable (default 0)")
 	flags.Var(&copts.blkioWeightDevice, "blkio-weight-device", "Block IO weight (relative device weight)")
 	flags.StringVar(&copts.containerIDFile, "cidfile", "", "Write the container ID to the file")
+	flags.StringVar(&copts.containerIDEnv, "cidenv", "", "Write the container ID to the environment variable")
 	flags.StringVar(&copts.cpusetCpus, "cpuset-cpus", "", "CPUs in which to allow execution (0-3, 0,1)")
 	flags.StringVar(&copts.cpusetMems, "cpuset-mems", "", "MEMs in which to allow execution (0-3, 0,1)")
 	flags.Int64Var(&copts.cpuCount, "cpu-count", 0, "CPU count (Windows only)")
@@ -577,6 +579,7 @@ func parse(flags *pflag.FlagSet, copts *containerOptions) (*containerConfig, err
 	hostConfig := &container.HostConfig{
 		Binds:           binds,
 		ContainerIDFile: copts.containerIDFile,
+		ContainerIDEnv:  copts.containerIDEnv,
 		OomScoreAdj:     copts.oomScoreAdj,
 		AutoRemove:      copts.autoRemove,
 		Privileged:      copts.privileged,


### PR DESCRIPTION
Allow settting HostConfig field ContainerIDEnv that provides a similar
purpose to ContainerIDFile (--cidfile) but instead using an environment variable.

Connects-to: https://github.com/balena-os/balena-engine/pull/174
Change-type: patch
Signed-off-by: Robert Günzler <robertg@balena.io>
