### PR TITLE
build: suppress legacy builder deprecation warnings

### DIFF
--- a/cmd/docker/builder.go
+++ b/cmd/docker/builder.go
@@ -81,10 +81,8 @@ func processBuilder(dockerCli command.Cli, cmd *cobra.Command, args, osargs []st
 	}
 
 	if buildKitDisabled {
-		// display warning if not wcow and continue
-		if dockerCli.ServerInfo().OSType != "windows" {
-			_, _ = fmt.Fprintf(dockerCli.Err(), "%s\n\n", buildkitDisabledWarning)
-		}
+		// balena-engine: suppress deprecation warning since we intentionally
+		// use the legacy builder and don't ship buildx
 		return args, osargs, nil, nil
 	}
 
@@ -99,8 +97,8 @@ func processBuilder(dockerCli command.Cli, cmd *cobra.Command, args, osargs []st
 		if useBuilder {
 			return args, osargs, nil, newBuilderError(buildxMissingError, perr)
 		}
-		// otherwise, display warning and continue
-		_, _ = fmt.Fprintf(dockerCli.Err(), "%s\n\n", newBuilderError(buildxMissingWarning, perr))
+		// balena-engine: suppress deprecation warning since we intentionally
+		// use the legacy builder and don't ship buildx
 		return args, osargs, nil, nil
 	}
 


### PR DESCRIPTION
balena-engine intentionally uses the legacy builder and does not ship the buildx plugin. The deprecation warnings are therefore inappropriate for this context and break integration tests that expect specific stderr behavior.

Suppress both buildkitDisabledWarning and buildxMissingWarning since they would only confuse balena-engine users.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

